### PR TITLE
Use the correct SOVER_EXT

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,6 +1,1 @@
-build_parameters:
-  - "--suppress-variables"
-  - "--error-overlinking"
-  - "-c https://staging.continuum.io/prefect/llvm-17.0.6-stage2-attempt-4"
-
 aggregate_check: false

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -16,7 +16,7 @@ cd clang
 
 IFS='.' read -r -a PKG_VER_ARRAY <<< "${PKG_VERSION}"
 # default SOVER for tagged releases is just the major version
-SOVER_EXT=${VER_ARR[0]}
+SOVER_EXT=${PKG_VER_ARRAY[0]}
 if [[ "${PKG_VERSION}" == *dev0 ]]; then
     # otherwise with git suffix
     SOVER_EXT="${SOVER_EXT}git"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set version = "17.0.6" %}
 {% set major_version = version.split(".")[0] %}
-{% set build_number = 5 %}
+{% set build_number = 6 %}
 
 {% set minor_aware_ext = major_version %}
 {% if version.split(".")[1] | int > 0 %}


### PR DESCRIPTION
Fixes empty SOVER_EXT causing things to look for `libLTO..dylib`.