### PR TITLE
Rebuild against libxml2 2.14

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -5,8 +5,4 @@ build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
 
-# Staging channel needed for LLVM 21 dependencies until promoted to pkgs/main
-channels:
-  - https://staging.continuum.io/pbp/llvm-21.1.8-stage2-build-0
-
 aggregate_check: false

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -26,3 +26,6 @@ variant:
 
 c_stdlib_version:   # [win]
   - 2022.14         # [win]
+
+libxml2:
+  - 2.14.4

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set version = "21.1.8" %}
 {% set major_version = version.split(".")[0] %}
 {% set tail_version = version.split(".")[-1] %}
-{% set build_number = 0 %}
+{% set build_number = 1 %}
 
 # always includes minor as of v18, see https://github.com/llvm/llvm-project/issues/76273
 {% set maj_min = major_version ~ "." ~ version.split(".")[1] %}


### PR DESCRIPTION
clangdev 21.1.8

**Destination channel:** defaults

### Links

- [PKG-12513](https://anaconda.atlassian.net/browse/PKG-12513) 
- [Upstream repository](https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8)

### Explanation of changes:
- New build number
- Update libxml2 version


[PKG-12513]: https://anaconda.atlassian.net/browse/PKG-12513?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ