### PR TITLE
PKG-12513 clangdev 20 rebuild against libxml2

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -3,4 +3,4 @@ aggregate_check: false
 build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
-  - "-c https://staging.continuum.io/prefect/llvm-20.1.8-stage2-build-0"
+

--- a/abs.yaml
+++ b/abs.yaml
@@ -4,3 +4,5 @@ build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
 
+# 4 hours timeout for Windows build (default is 2 hours)
+task_timeout: 14400

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -26,3 +26,5 @@ variant:
 
 c_stdlib_version:   # [win]
   - 2022.14         # [win]
+libxml2:
+  - 2.14.4

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set version = "20.1.8" %}
 {% set major_version = version.split(".")[0] %}
 {% set tail_version = version.split(".")[-1] %}
-{% set build_number = 0 %}
+{% set build_number = 1 %}
 
 # always includes minor as of v18, see https://github.com/llvm/llvm-project/issues/76273
 {% set maj_min = major_version ~ "." ~ version.split(".")[1] %}


### PR DESCRIPTION
clangdev 20.1.8

**Destination channel:**  defaults

### Links

- [PKG-12513](https://anaconda.atlassian.net/browse/PKG-12513) 
- [Upstream repository](https://github.com/llvm/llvm-project/tree/llvmorg-21.1.8)

### Explanation of changes:
- New build number
- Add pbp time limit
- Update libxml2 version


[PKG-12513]: https://anaconda.atlassian.net/browse/PKG-12513?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ