### PR TITLE
PKG-15272 rebuild clangdev 22 against libxml2 2.14

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set version = "22.1.2" %}
 {% set major_version = version.split(".")[0] %}
 {% set tail_version = version.split(".")[-1] %}
-{% set build_number = 0 %}
+{% set build_number = 1 %}
 
 # always includes minor as of v18, see https://github.com/llvm/llvm-project/issues/76273
 {% set maj_min = major_version ~ "." ~ version.split(".")[1] %}


### PR DESCRIPTION
## Links
- Jira: https://anaconda.atlassian.net/browse/PKG-15272

## Changes
- Bump build number to trigger rebuild against libxml2 2.14

## Notes
- libxml2 2.14 is already pinned in the global conda_build_config.yaml